### PR TITLE
Update $points command to use ?user_input=true

### DIFF
--- a/internal/commands/points/points.go
+++ b/internal/commands/points/points.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"url"
+	"net/url"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/pajbot/basecommand"
@@ -23,9 +23,9 @@ type Command struct {
 }
 
 type User struct {
-	DisplayName          string `json:"name"`
-	Points               int64  `json:"points"`
-	PointsRank           int64  `json:"points_rank"`
+	DisplayName string `json:"name"`
+	Points      int64  `json:"points"`
+	PointsRank  int64  `json:"points_rank"`
 }
 
 func New() *Command {
@@ -46,7 +46,7 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 
 	resp, err := http.Get(fmt.Sprintf("https://forsen.tv/api/v1/users/%s?user_input=true", url.PathEscape(target)))
 	if err != nil {
-		s.ChannelMessageSend(m.ChannelID, "There was an error getting that user's data: " + err.Error())
+		s.ChannelMessageSend(m.ChannelID, "There was an error getting that user's data: "+err.Error())
 		return
 	}
 
@@ -58,7 +58,7 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 	}
 
 	if resp.StatusCode >= 400 {
-		s.ChannelMessageSend(m.ChannelID, "There was an error getting that user's data: The API returned status code " + resp.StatusCode)
+		s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("There was an error getting that user's data: The API returned status code %d", resp.StatusCode))
 		return
 	}
 
@@ -66,7 +66,7 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 
 	err = json.NewDecoder(resp.Body).Decode(&user)
 	if err != nil {
-		s.ChannelMessageSend(m.ChannelID, "There was an error parsing the response from the API: " + err.Error())
+		s.ChannelMessageSend(m.ChannelID, "There was an error parsing the response from the API: "+err.Error())
 		return
 	}
 
@@ -74,6 +74,8 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 	resultMessage := fmt.Sprintf(resultFormat, m.Author.Mention(), user.DisplayName, user.Points, user.PointsRank)
 
 	s.ChannelMessageSend(m.ChannelID, resultMessage)
+
+	return
 }
 
 func (c *Command) Description() string {


### PR DESCRIPTION
`?user_input=true` allows more arcane queries like `$points @Snusbot`, `$points SNUSBOT`, or `$points 테스트계정420`

Also changed while I'm at it:
- Added handlers for HTTP status codes, so you no longer get `@randers, user  has 0 points.` when the user was not found.
- URL-encoded the input parameter so we're not sending unescaped stuff, just in case i guess
- Also output points_rank since it's useful now
- Removed pointless `return` at then end of the function

Would be nice if you could test this, since I made this in the web editor without trying it out, since I don't have a pajbot2-discord dev environment ready.