### PR TITLE
Don't escape reason in moderator log

### DIFF
--- a/internal/commands/ban/ban.go
+++ b/internal/commands/ban/ban.go
@@ -67,10 +67,10 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 	resultMessage := ""
 	if isAnonBan {
 		const resultFormat = "Banning %s for reason: %s"
-		resultMessage = fmt.Sprintf(resultFormat, utils.MentionUser(s, m.GuildID, target), utils.EscapeMarkdown(reason))
+		resultMessage = fmt.Sprintf(resultFormat, utils.MentionUser(s, m.GuildID, target), reason)
 	} else {
 		const resultFormat = "%s banned %s for reason: %s"
-		resultMessage = fmt.Sprintf(resultFormat, m.Author.Mention(), utils.MentionUser(s, m.GuildID, target), utils.EscapeMarkdown(reason))
+		resultMessage = fmt.Sprintf(resultFormat, m.Author.Mention(), utils.MentionUser(s, m.GuildID, target), reason)
 	}
 
 	s.ChannelMessageSend(m.ChannelID, resultMessage)


### PR DESCRIPTION
I added this in the last PR. I think it makes more sense to allow moderators to use markdown in the reason instead of escaping it.