### PR TITLE
Add ability to configure random values (e.g. pajbot_host)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unversioned
 
 - Minor: Moderator commands now also check for server ownership in addition to moderator role
+- Minor: Add ability to configure various uncategorized values using the `$configure value` command. Use `$configure value keys` to see a list of valid keys and their description. (#46)
+- Minor: The \$points command now has a configurable pajbot host instead of pointing at `forsen.tv`. Set it with `$configure value set pajbot_host forsen.tv`. (#46)

--- a/internal/commands/configure/configure.go
+++ b/internal/commands/configure/configure.go
@@ -108,8 +108,14 @@ func (c *Command) configureValue(s *discordgo.Session, m *discordgo.MessageCreat
 			return
 		}
 
-		const f = "%s, key %s reset. old value was %s"
-		r := fmt.Sprintf(f, m.Author.Mention(), key, oldValue)
+		var r string
+		if oldValue == "" {
+			const f = "%s, key %s reset"
+			r = fmt.Sprintf(f, m.Author.Mention(), key)
+		} else {
+			const f = "%s, key %s reset. old value was %s"
+			r = fmt.Sprintf(f, m.Author.Mention(), key, oldValue)
+		}
 		s.ChannelMessageSend(m.ChannelID, r)
 
 		return
@@ -149,8 +155,14 @@ func (c *Command) configureValue(s *discordgo.Session, m *discordgo.MessageCreat
 			return
 		}
 
-		const f = "%s, new value for key %s is %s (old value was %s)"
-		r := fmt.Sprintf(f, m.Author.Mention(), key, value, oldValue)
+		var r string
+		if oldValue == "" {
+			const f = "%s, new value for key %s is %s"
+			r = fmt.Sprintf(f, m.Author.Mention(), key, value)
+		} else {
+			const f = "%s, new value for key %s is %s (old value was %s)"
+			r = fmt.Sprintf(f, m.Author.Mention(), key, value, oldValue)
+		}
 		s.ChannelMessageSend(m.ChannelID, r)
 
 		return

--- a/internal/commands/configure/configure.go
+++ b/internal/commands/configure/configure.go
@@ -59,6 +59,108 @@ var discordEmojiRegex = regexp.MustCompile(`<(a)?:([^<>:]+):([0-9]+)>`)
 
 var unicodeEmojiRegex = regexp.MustCompile(`[\x{00A0}-\x{1F9EF}]`)
 
+// configureValue configures a generic value to be used elsewhere in the code
+// it's for values that might not make sense to have in a separate category (like channels)
+func (c *Command) configureValue(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) {
+	validKeys := map[string]string{
+		"pajbot_host": "The host used for any pajbot API requests and commands (like $points). Example value: forsen.tv. Assumes https schema and standard api path.",
+	}
+
+	const usage = "usage: $configure value (reset/set/get/keys) [key [value]]"
+	if len(parts) < 2 {
+		s.ChannelMessageSend(m.ChannelID, usage)
+		return
+	}
+
+	if parts[1] == "keys" {
+		var chunks []string
+		for validKey, keyDescription := range validKeys {
+			chunks = append(chunks, fmt.Sprintf("%s: %s\n", validKey, keyDescription))
+		}
+		utils.SendChunks("Valid keys:\n```", "```", chunks, m.ChannelID, s)
+
+		return
+	}
+
+	if len(parts) < 3 {
+		s.ChannelMessageSend(m.ChannelID, usage)
+		return
+	}
+
+	key := parts[2]
+
+	if _, ok := validKeys[key]; !ok {
+		const f = "%s, %s is not a valid key. use $configure value keys to see valid keys"
+		r := fmt.Sprintf(f, m.Author.Mention(), key)
+		s.ChannelMessageSend(m.ChannelID, r)
+		return
+	}
+
+	dbKey := fmt.Sprintf("value:%s", key)
+
+	oldValue := serverconfig.Get(m.GuildID, dbKey)
+
+	switch parts[1] {
+	case "reset":
+		err := serverconfig.Remove(commands.SQLClient, m.GuildID, dbKey)
+		if err != nil {
+			fmt.Println("Error removing value:", err)
+			return
+		}
+
+		const f = "%s, key %s reset. old value was %s"
+		r := fmt.Sprintf(f, m.Author.Mention(), key, oldValue)
+		s.ChannelMessageSend(m.ChannelID, r)
+
+		return
+
+	case "get":
+		if oldValue == "" {
+			const f = "%s, key %s has no value"
+			r := fmt.Sprintf(f, m.Author.Mention(), key)
+			s.ChannelMessageSend(m.ChannelID, r)
+
+			return
+		}
+
+		const f = "%s, key %s has the value %s"
+		r := fmt.Sprintf(f, m.Author.Mention(), key, oldValue)
+		s.ChannelMessageSend(m.ChannelID, r)
+
+		return
+
+	case "set":
+		const usage = "usage: $configure value set key value"
+		if len(parts) < 4 {
+			s.ChannelMessageSend(m.ChannelID, usage)
+			return
+		}
+
+		value := strings.Join(parts[3:], " ")
+
+		if len(value) == 0 {
+			s.ChannelMessageSend(m.ChannelID, "No valid value was set, use reset to remove the set value")
+			return
+		}
+
+		err := serverconfig.Save(commands.SQLClient, m.GuildID, dbKey, value)
+		if err != nil {
+			log.Println("SQL Error in set:", err)
+			return
+		}
+
+		const f = "%s, new value for key %s is %s (old value was %s)"
+		r := fmt.Sprintf(f, m.Author.Mention(), key, value, oldValue)
+		s.ChannelMessageSend(m.ChannelID, r)
+
+		return
+
+	default:
+		s.ChannelMessageSend(m.ChannelID, "Invalid key argument. "+usage)
+		return
+	}
+}
+
 func (c *Command) configureAutoReact(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) {
 	const usage = "usage: $configure autoreact (reset/set/get) EMOJIS..."
 	if len(parts) < 2 {
@@ -140,7 +242,7 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 	parts = parts[1:]
 
 	if len(parts) == 0 {
-		const usage = "usage: $configure autoreact/twitter/channel/role ..."
+		const usage = "usage: $configure autoreact/twitter/channel/role/value ..."
 		s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s, %s", m.Author.Mention(), usage))
 		return
 	}
@@ -150,6 +252,10 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 
 	// config type decides how we read the value
 	switch configType {
+	case "value":
+		// Configure a generic value
+		c.configureValue(s, m, parts)
+
 	case "autoreact":
 		c.configureAutoReact(s, m, parts)
 

--- a/internal/commands/points/points.go
+++ b/internal/commands/points/points.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/pajbot/basecommand"
+	"github.com/pajbot/pajbot2-discord/internal/serverconfig"
 	"github.com/pajbot/pajbot2-discord/pkg"
 	"github.com/pajbot/pajbot2-discord/pkg/commands"
 )
@@ -37,6 +38,13 @@ func New() *Command {
 func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) (res pkg.CommandResult) {
 	res = pkg.CommandResultUserCooldown
 
+	pajbotHost := serverconfig.Get(m.GuildID, "value:pajbot_host")
+
+	if pajbotHost == "" {
+		s.ChannelMessageSend(m.ChannelID, "This server does not have a pajbot host configured. Use the `$configure value` command to configure the `pajbot_host` key")
+		return pkg.CommandResultFullCooldown
+	}
+
 	if len(parts) < 2 {
 		s.ChannelMessageSend(m.ChannelID, "You need to provide a twitch username. usage: `$points <username>`")
 		return
@@ -44,7 +52,14 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 
 	target := parts[1]
 
-	resp, err := http.Get(fmt.Sprintf("https://forsen.tv/api/v1/users/%s?user_input=true", url.PathEscape(target)))
+	apiURL := url.URL{
+		Scheme:   "https",
+		Host:     pajbotHost,
+		Path:     fmt.Sprintf("api/v1/users/%s", target),
+		RawQuery: "user_input=true",
+	}
+
+	resp, err := http.Get(apiURL.String())
 	if err != nil {
 		s.ChannelMessageSend(m.ChannelID, "There was an error getting that user's data: "+err.Error())
 		return


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

- Add a way to configure the `pajbot_host` value used in places like $points
- Update the $points command to use the configurable `pajbot_host` value

Fixes #33