### PR TITLE
Add more positive responses to the eightball command

### DIFF
--- a/internal/commands/eightball/eightball.go
+++ b/internal/commands/eightball/eightball.go
@@ -49,6 +49,11 @@ var replies = []string{
 	"Yes.",
 	"Yes – definitely.",
 	"You may rely on it.",
+	"Absolutely not.",
+	"Not a chance.",
+	"No, I don't think so.",
+	"That's not very likely.",
+	"No way Jose.",
 }
 
 func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) pkg.CommandResult {


### PR DESCRIPTION
There were twice as many positive responses than negative responses. I've added in a few negative responses to balance it out. I also think it would be beneficial to remove the non-answers, but I haven't done that here.

Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
