### PR TITLE
feat: add colors to $colors command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Minor: Add ability to configure various uncategorized values using the `$configure value` command. Use `$configure value keys` to see a list of valid keys and their description. (#46)
 - Minor: The \$points command now has a configurable pajbot host instead of pointing at `forsen.tv`. Set it with `$configure value set pajbot_host forsen.tv`. (#46)
 - Minor: Added $8ball command
+- Minor: Make $colors command output colorful
 - Dev: Bumped minimum Go version to 1.19. (#111)
 - Dev: Bumped minimum Go version to 1.18. (#106)
 - Dev: Bumped minimum Go version to 1.17. (#97)

--- a/internal/commands/colors/colors.go
+++ b/internal/commands/colors/colors.go
@@ -1,13 +1,12 @@
 package roleinfo
 
 import (
-	"fmt"
-
 	"github.com/bwmarrin/discordgo"
 	"github.com/pajbot/basecommand"
 	"github.com/pajbot/pajbot2-discord/pkg"
 	"github.com/pajbot/pajbot2-discord/pkg/commands"
 	"github.com/pajbot/pajbot2-discord/pkg/utils"
+	"strings"
 )
 
 func init() {
@@ -33,7 +32,7 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 	colorRoles := utils.ColorRoles(s, m.GuildID)
 	var roleNames []string
 	for _, role := range colorRoles {
-		roleNames = append(roleNames, role.Name)
+		roleNames = append(roleNames, role.Mention())
 	}
 
 	if len(roleNames) == 0 {
@@ -41,7 +40,10 @@ func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []
 		return
 	}
 
-	s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("These are the available colors: %s", roleNames))
+	s.ChannelMessageSendEmbed(m.ChannelID, &discordgo.MessageEmbed{
+		Title:       "These are the available colors:",
+		Description: strings.Join(roleNames, " "),
+	})
 	return pkg.CommandResultUserCooldown
 }
 


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description
Updated `$colors` command to actually display role colors via mentions in embed.
<img width="529" alt="image" src="https://user-images.githubusercontent.com/9158397/221182512-6e533c92-2336-4320-ba5d-d5d9c5a569d7.png">
