### PR TITLE
feat: add simple roll command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minor: The \$points command now has a configurable pajbot host instead of pointing at `forsen.tv`. Set it with `$configure value set pajbot_host forsen.tv`. (#46)
 - Minor: Added $8ball command
 - Minor: Make $colors command output colorful
+- Minor: Add $roll command
 - Dev: Bumped minimum Go version to 1.19. (#111)
 - Dev: Bumped minimum Go version to 1.18. (#106)
 - Dev: Bumped minimum Go version to 1.17. (#97)

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/profile"
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/roleinfo"
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/roles"
+	_ "github.com/pajbot/pajbot2-discord/internal/commands/roll"
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/tags"
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/test"
 	_ "github.com/pajbot/pajbot2-discord/internal/commands/userid"

--- a/internal/commands/roll/roll.go
+++ b/internal/commands/roll/roll.go
@@ -1,0 +1,47 @@
+package roll
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/basecommand"
+	"github.com/pajbot/pajbot2-discord/pkg"
+	"github.com/pajbot/pajbot2-discord/pkg/commands"
+)
+
+var _ pkg.Command = &Command{}
+
+func init() {
+	commands.Register([]string{
+		"$roll",
+	}, New())
+}
+
+type Command struct {
+	basecommand.Command
+}
+
+func New() *Command {
+	return &Command{
+		Command: basecommand.New(),
+	}
+}
+
+func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) pkg.CommandResult {
+	if len(parts) >= 2 {
+		var number, err = strconv.Atoi(parts[1])
+		if err == nil && number >= 1 {
+			var response = discordgo.MessageSend{
+				Content: fmt.Sprintf("%s, %d", m.Author.Mention(), rand.Intn(number)),
+			}
+			s.ChannelMessageSendComplex(m.ChannelID, &response)
+		}
+	}
+	return pkg.CommandResultFullCooldown
+}
+
+func (c *Command) Description() string {
+	return c.Command.Description
+}

--- a/internal/commands/roll/roll.go
+++ b/internal/commands/roll/roll.go
@@ -31,9 +31,9 @@ func New() *Command {
 
 func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) pkg.CommandResult {
 	if len(parts) >= 2 {
-		var number, err = strconv.Atoi(parts[1])
+		number, err := strconv.Atoi(parts[1])
 		if err == nil && number >= 1 {
-			var response = discordgo.MessageSend{
+			response := discordgo.MessageSend{
 				Content: fmt.Sprintf("%s, %d", m.Author.Mention(), rand.Intn(number)),
 			}
 			s.ChannelMessageSendComplex(m.ChannelID, &response)


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Add a very simple `$roll <number>` command, several people wanted something like that instead of using limited `$ping` for randomness
<img width="244" alt="image" src="https://user-images.githubusercontent.com/9158397/225834096-a358cabd-418e-432b-89ee-112c4de7c5bc.png">
