### PR TITLE
Add basic support for slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unversioned
+## 2023-04-10
+
+- Add basic support for slash commands. (#81)
+
+## Undated
 
 - Minor: Moderator commands now also check for server ownership in addition to moderator role
 - Minor: Add ability to configure various uncategorized values using the `$configure value` command. Use `$configure value keys` to see a list of valid keys and their description. (#46)

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pajbot/pajbot2-discord/internal/filter"
 	"github.com/pajbot/pajbot2-discord/internal/mute"
 	"github.com/pajbot/pajbot2-discord/internal/serverconfig"
+	"github.com/pajbot/pajbot2-discord/internal/slashcommands"
 	"github.com/pajbot/pajbot2-discord/pkg"
 	"github.com/pajbot/pajbot2-discord/pkg/commands"
 	"github.com/pajbot/pajbot2-discord/pkg/utils"
@@ -256,6 +257,15 @@ func main() {
 
 	defer bot.Close()
 
+	slashcommands := slashcommands.New(config.SlashCommandGuildIDs)
+
+	// Create all slash commands
+	err = slashcommands.Create(bot)
+	if err != nil {
+		fmt.Println("Error creating slash commands:", err)
+		return
+	}
+
 	// Run queued up actions (e.g. unmute user)
 	go startActionRunner(ctx, bot)
 	// Run queued up unmutes
@@ -269,6 +279,13 @@ func main() {
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
 	<-sc
+
+	// Delete all registered slash commands
+	err = slashcommands.Delete(bot)
+	if err != nil {
+		fmt.Println("Error creating slash commands:", err)
+		return
+	}
 }
 
 func pushMessageIntoDatabase(m *discordgo.Message) (err error) {

--- a/docs/systemd-example/pajbot2-discord.service.d/10-slash-commands.conf
+++ b/docs/systemd-example/pajbot2-discord.service.d/10-slash-commands.conf
@@ -1,0 +1,3 @@
+[Service]
+# Enable all slash commands in guilds 12345 and 67890
+Environment=PAJBOT2_DISCORD_BOT_SLASH_COMMAND_GUILD_IDS="12345,67890"

--- a/internal/commands/ping/ping.go
+++ b/internal/commands/ping/ping.go
@@ -36,8 +36,12 @@ var vowels = []rune{
 	'a', 'e', 'i', 'o', 'u',
 }
 
+func GetPingResponse() string {
+	return fmt.Sprintf("p%cng", vowels[rand.Intn(len(vowels))])
+}
+
 func (c *Command) Run(s *discordgo.Session, m *discordgo.MessageCreate, parts []string) pkg.CommandResult {
-	response := fmt.Sprintf("%s, p%cng", m.Author.Mention(), vowels[rand.Intn(len(vowels))])
+	response := fmt.Sprintf("%s, %s", m.Author.Mention(), GetPingResponse())
 	s.ChannelMessageSend(m.ChannelID, response)
 	return pkg.CommandResultFullCooldown
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,9 @@ var (
 
 	Token string
 
+	// Guild IDs in which to enable all slash commands
+	SlashCommandGuildIDs []string
+
 	// Twitter
 	TwitterConsumerKey       string
 	TwitterConsumerSecret    string
@@ -24,6 +27,8 @@ func init() {
 	DSN = stringEnv(envName("SQL_DSN"), "postgres:///pajbot2_discord?sslmode=disable")
 
 	Token = mustStringEnv(envName("TOKEN"))
+
+	SlashCommandGuildIDs = cleanList(stringListEnv(envName("SLASH_COMMAND_GUILD_IDS"), []string{}))
 
 	// Twitter
 	TwitterConsumerKey = stringEnv(envName("TWITTER_CONSUMER_KEY"), "")

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 func mustStringEnv(key string) string {
 	if value, ok := os.LookupEnv(key); ok {
@@ -13,6 +16,14 @@ func mustStringEnv(key string) string {
 func stringEnv(key string, defaultValue string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
+	}
+
+	return defaultValue
+}
+
+func stringListEnv(key string, defaultValue []string) []string {
+	if value, ok := os.LookupEnv(key); ok {
+		return strings.Split(value, ",")
 	}
 
 	return defaultValue

--- a/internal/config/helpers.go
+++ b/internal/config/helpers.go
@@ -1,0 +1,13 @@
+package config
+
+import "strings"
+
+func cleanList(in []string) []string {
+	out := make([]string, len(in))
+
+	for i, v := range in {
+		out[i] = strings.TrimSpace(v)
+	}
+
+	return out
+}

--- a/internal/slashcommands/ping.go
+++ b/internal/slashcommands/ping.go
@@ -1,0 +1,27 @@
+package slashcommands
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/commands/ping"
+)
+
+func init() {
+	cmd := &SlashCommand{
+		name: "ping",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Ping Pong",
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: ping.GetPingResponse(),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}

--- a/internal/slashcommands/slashcommands.go
+++ b/internal/slashcommands/slashcommands.go
@@ -70,7 +70,7 @@ func (s *SlashCommands) Create(session *discordgo.Session) error {
 		for _, cmd := range commands {
 			registeredCommand, err := session.ApplicationCommandCreate(session.State.User.ID, guildID, cmd.command)
 			if err != nil {
-				return fmt.Errorf("Error creating command %v: %w", cmd, err)
+				return fmt.Errorf("creating command '%s' failed: %w", cmd.name, err)
 			}
 			cmd.registeredCommands = append(cmd.registeredCommands, registeredCommand)
 		}

--- a/internal/slashcommands/slashcommands.go
+++ b/internal/slashcommands/slashcommands.go
@@ -1,0 +1,101 @@
+package slashcommands
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type SlashCommand struct {
+	name    string
+	command *discordgo.ApplicationCommand
+
+	handler func(*discordgo.Session, *discordgo.InteractionCreate)
+
+	registeredCommands []*discordgo.ApplicationCommand
+}
+
+type SlashCommands struct {
+	guildIDs []string
+}
+
+var commands = map[string]*SlashCommand{}
+
+// register registers a slash command to be created on the configured guilds
+// read the code or the /ping command to see how the command should be created
+// we will panic if something is misconfigured
+func register(cmd *SlashCommand) {
+	if cmd.name == "" {
+		log.Fatal("Command must have a name")
+	}
+
+	if cmd.command == nil {
+		log.Fatalf("[%s] Command must have `command` set", cmd.name)
+	}
+
+	if len(cmd.registeredCommands) != 0 {
+		log.Fatalf("[%s] Command must NOT have any `registeredCommands` set", cmd.name)
+	}
+
+	if cmd.handler == nil {
+		log.Fatalf("[%s] Command must have `handler` set", cmd.name)
+	}
+
+	if cmd.command.Name != "" {
+		log.Fatalf("[%s] `command.Name` must not be set", cmd.name)
+	}
+	cmd.command.Name = cmd.name
+
+	if _, ok := commands[cmd.name]; ok {
+		log.Fatalf("[%s] Command with the name '%s' has already been registered", cmd.name, cmd.name)
+	}
+
+	commands[cmd.name] = cmd
+}
+
+func onInteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	if cmd, ok := commands[i.ApplicationCommandData().Name]; ok {
+		cmd.handler(s, i)
+	}
+}
+
+// Create registers all available slash commands in the guilds listed in the config
+func (s *SlashCommands) Create(session *discordgo.Session) error {
+	session.AddHandler(onInteractionCreate)
+
+	for _, guildID := range s.guildIDs {
+		log.Println("Creating slash commands for guild", guildID)
+
+		for _, cmd := range commands {
+			registeredCommand, err := session.ApplicationCommandCreate(session.State.User.ID, guildID, cmd.command)
+			if err != nil {
+				return fmt.Errorf("Error creating command %v: %w", cmd, err)
+			}
+			cmd.registeredCommands = append(cmd.registeredCommands, registeredCommand)
+		}
+	}
+
+	return nil
+}
+
+// Delete deletes all slash commands that were registered in all guilds
+func (s *SlashCommands) Delete(session *discordgo.Session) error {
+	for _, cmd := range commands {
+		for _, registeredCommand := range cmd.registeredCommands {
+			err := session.ApplicationCommandDelete(session.State.User.ID, registeredCommand.GuildID, registeredCommand.ID)
+			if err != nil {
+				log.Printf("Error deleting command %v: %s", cmd, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// New creates a SlashCommands struct with the given options
+func New(guildIDs []string) *SlashCommands {
+	return &SlashCommands{
+		guildIDs: guildIDs,
+	}
+}


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Guild IDs are configured with the `PAJBOT2_DISCORD_BOT_SLASH_COMMAND_GUILD_IDS` environment variable

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
