### PR TITLE
Channel Topic Role thingmabob

### DIFF
--- a/cmd/bot/migrations/1763900045-create-channel-topic-roles-table.sql
+++ b/cmd/bot/migrations/1763900045-create-channel-topic-roles-table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE channel_topic_roles (
+    role_id TEXT NOT NULL,
+    guild_id TEXT NOT NULL,
+    channel_id TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+
+    last_invoked TIMESTAMP with time zone NOT NULL,
+    last_invoker_id TEXT NULL
+
+    PRIMARY KEY (role_id, guild_id)
+)
+
+CREATE INDEX channel_topic_roles_last_invoker_idx ON channel_topic_roles (last_invoker_id, guild_id);
+
+comment on column channel_topic_roles.role_id is 'Discord role ID';
+comment on column channel_topic_roles.guild_id is 'Discord server/guild ID';
+comment on column channel_topic_roles.channel_id is 'Discord channel ID';
+comment on column channel_topic_roles.created_by is 'Discord user ID of the user who created the role';
+
+comment on column channel_topic_roles.last_invoked is 'Timestamp of the last time the at ping command was invoked';
+comment on column channel_topic_roles.last_invoker_id is 'Discord user ID of the user who last invoked the at ping command';

--- a/internal/channelrole/channelrole.go
+++ b/internal/channelrole/channelrole.go
@@ -1,0 +1,158 @@
+package channelrole
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channels"
+	"github.com/pajbot/pajbot2-discord/pkg/commands"
+	"github.com/pajbot/pajbot2-discord/pkg/utils"
+)
+
+const ChannelRolePingCooldownMinutes = 10 * time.Minute
+
+func CanChannelRolePing(s *discordgo.Session, guildID, userID, channelID, roleID string) (canPing bool, errorMessage string) {
+	// Does the user have the role that they are trying to ping?
+	userInRole, err := utils.MemberInRoles(s, guildID, userID, roleID)
+	if err != nil {
+		return false, err.Error()
+	}
+	if !userInRole {
+		return false, "You need to have the role that you are mentioning to ping it."
+	}
+
+	// Did the user invoke any at ping command inside this guild in the last 10 minutes?
+	inCooldown, errorMessage := IsUserInCooldown(userID, guildID)
+	if inCooldown {
+		return false, errorMessage
+	}
+
+	const query = "SELECT last_invoked, last_invoker_id, channel_id FROM channel_topic_roles WHERE role_id=$1 AND guild_id=$2"
+
+	row := commands.SQLClient.QueryRow(query, roleID, guildID)
+
+	var lastInvoked time.Time
+	var lastInvokerID string
+	var dbChannelID string
+
+	err = row.Scan(&lastInvoked, &lastInvokerID, &dbChannelID)
+	if err != nil {
+		return false, err.Error()
+	}
+
+	// Was this role pinged within the last 10 minutes?
+	if time.Since(lastInvoked) < ChannelRolePingCooldownMinutes {
+		return false, "You cannot ping the same role within the last 10 minutes."
+	}
+
+	// Was this role pinged in a different channel?
+	if dbChannelID != channelID {
+		return false, "You cannot ping this role in this channel."
+	}
+
+	return true, ""
+}
+
+func IsUserInCooldown(userID string, guildID string) (inCooldown bool, errorMessage string) {
+	const query = "SELECT last_invoked FROM channel_topic_roles WHERE last_invoker_id=$1 AND guild_id=$2"
+
+	var lastInvoked time.Time
+
+	rows, err := commands.SQLClient.Query(query, userID)
+	if err != nil {
+		return false, err.Error()
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		err = rows.Scan(&lastInvoked)
+		if err != nil {
+			return false, err.Error()
+		}
+
+		if time.Since(lastInvoked) < ChannelRolePingCooldownMinutes {
+			return true, "You are in cooldown. Please wait before pinging again."
+		}
+	}
+
+	return false, ""
+}
+
+func UpdateLastInvoked(s *discordgo.Session, user *discordgo.User, guildID string, roleID string, roleName string) error {
+	const updateQuery = "UPDATE channel_topic_roles SET last_invoked=$1, last_invoker_id=$2 WHERE role_id=$3 AND guild_id=$4"
+
+	_, err := commands.SQLClient.Exec(updateQuery, time.Now(), user.ID, roleID, guildID)
+	if err != nil {
+		return err
+	}
+
+	targetChannel, err := getActionLogChannel(guildID)
+	if err != nil {
+		return err
+	}
+
+	message := fmt.Sprintf("Channel role %s (%s) invoked by %s", roleName, roleID, utils.MentionUser(s, guildID, user))
+
+	s.ChannelMessageSend(targetChannel, message)
+
+	return nil
+}
+
+func Create(s *discordgo.Session, moderator *discordgo.User, guildID string, channelID string, roleID string, roleName string) error {
+	const createQuery = "INSERT INTO channel_topic_roles (role_id, guild_id, channel_id, created_by, last_invoked) VALUES ($1, $2, $3, $4, $5)"
+	_, err := commands.SQLClient.Exec(createQuery, roleID, guildID, channelID, moderator.ID, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		return err
+	}
+
+	targetChannel, err := getActionLogChannel(guildID)
+	if err != nil {
+		return err
+	}
+
+	message := fmt.Sprintf("Channel role %s (%s) created by %s", roleName, roleID, utils.MentionUser(s, guildID, moderator))
+	s.ChannelMessageSendComplex(targetChannel, &discordgo.MessageSend{
+		Content: message,
+		AllowedMentions: &discordgo.MessageAllowedMentions{
+			Users: []string{},
+		},
+	})
+
+	return nil
+}
+
+func Delete(s *discordgo.Session, moderator *discordgo.User, guildID string, roleID string, roleName string) error {
+	const deleteQuery = "DELETE FROM channel_topic_roles WHERE role_id=$1 AND guild_id=$2"
+
+	_, err := commands.SQLClient.Exec(deleteQuery, roleID, guildID)
+	if err != nil {
+		return err
+	}
+
+	targetChannel, err := getActionLogChannel(guildID)
+	if err != nil {
+		return err
+	}
+
+	message := fmt.Sprintf("Channel role %s (%s) deleted by %s", roleName, roleID, utils.MentionUser(s, guildID, moderator))
+	s.ChannelMessageSendComplex(targetChannel, &discordgo.MessageSend{
+		Content: message,
+		AllowedMentions: &discordgo.MessageAllowedMentions{
+			Users: []string{},
+		},
+	})
+
+	return nil
+}
+
+func getActionLogChannel(guildID string) (string, error) {
+	targetChannel := channels.Get(guildID, "action-log")
+	if targetChannel == "" {
+		fmt.Println("No channel set up for action log")
+		return "", fmt.Errorf("no channel set up for action log")
+	}
+
+	return targetChannel, nil
+}

--- a/internal/channelrole/channelrole.go
+++ b/internal/channelrole/channelrole.go
@@ -94,10 +94,21 @@ func UpdateLastInvoked(s *discordgo.Session, user *discordgo.User, guildID strin
 	}
 
 	message := fmt.Sprintf("Channel role %s (%s) invoked by %s", roleName, roleID, utils.MentionUser(s, guildID, user))
-
 	s.ChannelMessageSend(targetChannel, message)
 
 	return nil
+}
+
+func IsChannelRole(guildID string, roleID string) (isChannelRole bool, errorMessage string) {
+	const query = "SELECT COUNT(*) FROM channel_topic_roles WHERE role_id=$1 AND guild_id=$2"
+
+	var count int
+	err := commands.SQLClient.QueryRow(query, roleID, guildID).Scan(&count)
+	if err != nil {
+		return false, err.Error()
+	}
+
+	return count == 1, ""
 }
 
 func Create(s *discordgo.Session, moderator *discordgo.User, guildID string, channelID string, roleID string, roleName string) error {

--- a/internal/slashcommands/at.go
+++ b/internal/slashcommands/at.go
@@ -93,6 +93,10 @@ func init() {
 			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
+					AllowedMentions: &discordgo.MessageAllowedMentions{
+						Users: []string{executingUser.ID},
+						Roles: []string{roleToMention.ID},
+					},
 					Content: fmt.Sprintf("*from %s to %s*\n %s", utils.MentionUser(s, i.GuildID, executingUser), roleToMention.Mention(), message),
 				},
 			})

--- a/internal/slashcommands/at.go
+++ b/internal/slashcommands/at.go
@@ -38,11 +38,11 @@ func init() {
 			} else if i.User != nil {
 				executingUser = i.User
 			} else {
-				fmt.Println("no user found for at comnmand")
+				fmt.Println("No user found for at command")
 				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
-						Content: "no user found for at command",
+						Content: "No user found for at command",
 					},
 				})
 				return
@@ -56,7 +56,7 @@ func init() {
 				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
-						Content: "an invalid role was passed to the at command",
+						Content: "An invalid role was passed to the at command",
 					},
 				})
 				return
@@ -66,7 +66,7 @@ func init() {
 				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
-						Content: "an invalid message was passed to the at command",
+						Content: "An invalid message was passed to the at command",
 					},
 				})
 				return

--- a/internal/slashcommands/at.go
+++ b/internal/slashcommands/at.go
@@ -1,0 +1,103 @@
+package slashcommands
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channelrole"
+	"github.com/pajbot/pajbot2-discord/pkg/utils"
+)
+
+func init() {
+	cmd := &SlashCommand{
+		name: "at",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Mention a topic role inside a channel",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionRole,
+					Name:        "role",
+					Description: "Role to mention",
+					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "message",
+					Description: "Your beautiful message",
+					Required:    true,
+				},
+			},
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			var executingUser *discordgo.User
+
+			if i.Member != nil {
+				executingUser = i.Member.User
+			} else if i.User != nil {
+				executingUser = i.User
+			} else {
+				fmt.Println("no user found for at comnmand")
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "no user found for at command",
+					},
+				})
+				return
+			}
+
+			options := i.ApplicationCommandData().Options
+			roleToMention := options[0].RoleValue(s, i.GuildID)
+			message := options[1].StringValue()
+
+			if roleToMention == nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "an invalid role was passed to the at command",
+					},
+				})
+				return
+			}
+
+			if message == "" {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "an invalid message was passed to the at command",
+					},
+				})
+				return
+			}
+
+			canPing, errorMessage := channelrole.CanChannelRolePing(s, i.GuildID, executingUser.ID, i.ChannelID, roleToMention.ID)
+
+			if !canPing && errorMessage != "" {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: errorMessage,
+					},
+				})
+				return
+			}
+
+			err := channelrole.UpdateLastInvoked(s, executingUser, i.GuildID, roleToMention.ID, roleToMention.Name)
+			if err != nil {
+				fmt.Println("Error updating last invoked channel role ping:", err)
+			}
+
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: fmt.Sprintf("*from %s to %s*\n %s", utils.MentionUser(s, i.GuildID, executingUser), roleToMention.Mention(), message),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}

--- a/internal/slashcommands/channelrolecreate.go
+++ b/internal/slashcommands/channelrolecreate.go
@@ -1,0 +1,117 @@
+package slashcommands
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channelrole"
+)
+
+func init() {
+	var perms int64 = discordgo.PermissionManageRoles
+	cmd := &SlashCommand{
+		name: "createchannelrole",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Creates a new channel role",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "name",
+					Description: "Name of the new channel role",
+					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionChannel,
+					Name:        "channel",
+					Description: "Channel to bind the role to",
+					Required:    true,
+				},
+			},
+			DefaultMemberPermissions: &perms,
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			var moderator *discordgo.User
+
+			if i.Member != nil {
+				moderator = i.Member.User
+			} else if i.User != nil {
+				moderator = i.User
+			} else {
+				fmt.Println("no moderator found?")
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "no moderator found?",
+					},
+				})
+				return
+			}
+
+			options := i.ApplicationCommandData().Options
+			name := options[1].StringValue()
+			channel := options[2].ChannelValue(s)
+			channelID := channel.ID
+
+			if name == "" {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "an invalid name was passed to the create channel role command",
+					},
+				})
+				return
+			}
+
+			if channelID == "" {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "an invalid channel was passed to the create channel role command",
+					},
+				})
+				return
+			}
+
+			role, err := s.GuildRoleCreate(i.GuildID, &discordgo.RoleParams{
+				Name: name,
+			})
+
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "an invalid channel was passed to the create channel role command",
+					},
+				})
+				return
+			}
+
+			err = channelrole.Create(s, moderator, i.GuildID, channelID, role.ID, role.Name)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "error creating channel role:" + err.Error(),
+					},
+				})
+				return
+			}
+
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:   discordgo.MessageFlagsEphemeral,
+					Content: fmt.Sprintf("Channel role %s created and bound to %s", name, channelID),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}

--- a/internal/slashcommands/channelrolecreate.go
+++ b/internal/slashcommands/channelrolecreate.go
@@ -39,11 +39,11 @@ func init() {
 			} else if i.User != nil {
 				moderator = i.User
 			} else {
-				fmt.Println("no moderator found?")
+				fmt.Println("No moderator found?")
 				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
-						Content: "no moderator found?",
+						Content: "No moderator found?",
 					},
 				})
 				return
@@ -59,7 +59,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "an invalid name was passed to the create channel role command",
+						Content: "An invalid name was passed to the create channel role command",
 					},
 				})
 				return
@@ -70,7 +70,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "an invalid channel was passed to the create channel role command",
+						Content: "An invalid channel was passed to the create channel role command",
 					},
 				})
 				return
@@ -85,7 +85,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "an invalid channel was passed to the create channel role command",
+						Content: "An invalid channel was passed to the create channel role command",
 					},
 				})
 				return
@@ -97,7 +97,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "error creating channel role:" + err.Error(),
+						Content: "Error creating channel role:" + err.Error(),
 					},
 				})
 				return

--- a/internal/slashcommands/channelroledelete.go
+++ b/internal/slashcommands/channelroledelete.go
@@ -63,7 +63,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "error deleting channel role:" + err.Error(),
+						Content: "Error deleting channel role:" + err.Error(),
 					},
 				})
 			}
@@ -74,7 +74,7 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "error deleting channel role:" + err.Error(),
+						Content: "Error deleting channel role:" + err.Error(),
 					},
 				})
 			}

--- a/internal/slashcommands/channelroledelete.go
+++ b/internal/slashcommands/channelroledelete.go
@@ -1,0 +1,93 @@
+package slashcommands
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channelrole"
+)
+
+func init() {
+	var perms int64 = discordgo.PermissionManageRoles
+	cmd := &SlashCommand{
+		name: "deletechannelrole",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Deletes a channel role",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionRole,
+					Name:        "role",
+					Description: "Role to delete",
+					Required:    true,
+				},
+			},
+			DefaultMemberPermissions: &perms,
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			var moderator *discordgo.User
+
+			if i.Member != nil {
+				moderator = i.Member.User
+			} else if i.User != nil {
+				moderator = i.User
+			} else {
+				fmt.Println("no moderator found?")
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "no moderator found?",
+					},
+				})
+				return
+			}
+
+			options := i.ApplicationCommandData().Options
+			roleToDelete := options[0].RoleValue(s, i.GuildID)
+
+			if roleToDelete == nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "an invalid role was passed to the delete channel role command",
+					},
+				})
+				return
+			}
+
+			err := channelrole.Delete(s, moderator, i.GuildID, roleToDelete.ID, roleToDelete.Name)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "error deleting channel role:" + err.Error(),
+					},
+				})
+			}
+
+			s.GuildRoleDelete(i.GuildID, roleToDelete.ID)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "error deleting channel role:" + err.Error(),
+					},
+				})
+			}
+
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:   discordgo.MessageFlagsEphemeral,
+					Content: fmt.Sprintf("Channel role %s deleted", roleToDelete.Name),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}

--- a/internal/slashcommands/channelrolesubscribe.go
+++ b/internal/slashcommands/channelrolesubscribe.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channelrole"
 	"github.com/pajbot/pajbot2-discord/pkg/utils"
 )
 
@@ -31,11 +32,11 @@ func init() {
 			} else if i.User != nil {
 				executingUser = i.User
 			} else {
-				fmt.Println("no user found for self-mute?")
+				fmt.Println("No user found for subscribe?")
 				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
-						Content: "no user found for self-mute?",
+						Content: "No user found for subscribe?",
 					},
 				})
 				return
@@ -71,7 +72,20 @@ func init() {
 					Type: discordgo.InteractionResponseChannelMessageWithSource,
 					Data: &discordgo.InteractionResponseData{
 						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: "you are already subscribed to this role",
+						Content: "You are already subscribed to this role",
+					},
+				})
+				return
+			}
+
+			// Check if the role is a channel topic role, otherwise we won't allow them to subscribe to it.
+			isChannelRole, _ := channelrole.IsChannelRole(i.GuildID, roleToSubscribe.ID)
+			if !isChannelRole {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "This role is not a channel topic role",
 					},
 				})
 				return

--- a/internal/slashcommands/channelrolesubscribe.go
+++ b/internal/slashcommands/channelrolesubscribe.go
@@ -1,0 +1,102 @@
+package slashcommands
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/pkg/utils"
+)
+
+func init() {
+	cmd := &SlashCommand{
+		name: "subscribe",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Subscribe to a channel topic role",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionRole,
+					Name:        "role",
+					Description: "Role to subscribe to",
+					Required:    true,
+				},
+			},
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			var executingUser *discordgo.User
+
+			if i.Member != nil {
+				executingUser = i.Member.User
+			} else if i.User != nil {
+				executingUser = i.User
+			} else {
+				fmt.Println("no user found for self-mute?")
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "no user found for self-mute?",
+					},
+				})
+				return
+			}
+
+			options := i.ApplicationCommandData().Options
+			roleToSubscribe := options[0].RoleValue(s, i.GuildID)
+			if roleToSubscribe == nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "an invalid role was passed to the subscribe command",
+					},
+				})
+				return
+			}
+
+			userInRole, err := utils.MemberInRoles(s, i.GuildID, executingUser.ID, roleToSubscribe.ID)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "error checking role status:" + err.Error(),
+					},
+				})
+				return
+			}
+
+			if userInRole {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "you are already subscribed to this role",
+					},
+				})
+				return
+			}
+
+			err = s.GuildMemberRoleAdd(i.GuildID, executingUser.ID, roleToSubscribe.ID)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "error adding role:" + err.Error(),
+					},
+				})
+			}
+
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:   discordgo.MessageFlagsEphemeral,
+					Content: fmt.Sprintf("You are now subscribed to %s", roleToSubscribe.Name),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}

--- a/internal/slashcommands/channelroleunsubscribe.go
+++ b/internal/slashcommands/channelroleunsubscribe.go
@@ -1,0 +1,116 @@
+package slashcommands
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/pajbot/pajbot2-discord/internal/channelrole"
+	"github.com/pajbot/pajbot2-discord/pkg/utils"
+)
+
+func init() {
+	cmd := &SlashCommand{
+		name: "unsubscribe",
+
+		command: &discordgo.ApplicationCommand{
+			Description: "Unsubscribe from a channel topic role",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionRole,
+					Name:        "role",
+					Description: "Role to unsubscribe from",
+					Required:    true,
+				},
+			},
+		},
+
+		handler: func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			var executingUser *discordgo.User
+
+			if i.Member != nil {
+				executingUser = i.Member.User
+			} else if i.User != nil {
+				executingUser = i.User
+			} else {
+				fmt.Println("No user found for unsubscribe?")
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Content: "No user found for unsubscribe?",
+					},
+				})
+				return
+			}
+
+			options := i.ApplicationCommandData().Options
+			roleToUnsubscribe := options[0].RoleValue(s, i.GuildID)
+			if roleToUnsubscribe == nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "An invalid role was passed to the subscribe command",
+					},
+				})
+				return
+			}
+
+			userInRole, err := utils.MemberInRoles(s, i.GuildID, executingUser.ID, roleToUnsubscribe.ID)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "Error checking role status:" + err.Error(),
+					},
+				})
+				return
+			}
+
+			if !userInRole {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "You are not subscribed to this role",
+					},
+				})
+				return
+			}
+
+			// Check if the role is a channel topic role, otherwise we won't allow them to unsubscribe from it.
+			isChannelRole, _ := channelrole.IsChannelRole(i.GuildID, roleToUnsubscribe.ID)
+			if !isChannelRole {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "This role is not a channel topic role",
+					},
+				})
+				return
+			}
+
+			err = s.GuildMemberRoleRemove(i.GuildID, executingUser.ID, roleToUnsubscribe.ID)
+			if err != nil {
+				s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:   discordgo.MessageFlagsEphemeral,
+						Content: "Error removing role:" + err.Error(),
+					},
+				})
+			}
+
+			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:   discordgo.MessageFlagsEphemeral,
+					Content: fmt.Sprintf("You are now unsubscribed from %s", roleToUnsubscribe.Name),
+				},
+			})
+		},
+	}
+
+	register(cmd)
+}


### PR DESCRIPTION
As before, it's kind of a pain to set this up locally, so I haven't tested 👍 

This PR adds a couple of new slash commands.

# User commands:
## /at {role} {message}
/at can be invoked by any user, however there are some prerequisites:
- User must have the role themselves
- User must not have invoked any channel role pings (globally per guild) in the last 10 minutes
- The specific role must not have been invoked by any other users in the last 10 minutes

## /subscribe {role}
/subscribe can be invoked any user.
- If the user already has the role, nothing happens
- Validation is applied to ensure the role is a channel topic role

## /unsubscribe {role}
/unsubscribe can be invoked by any user.
- If the user doesn't have the role, nothing happens.
- Validation is applied to ensure the role is a channel topic role

# Mod commands:
## /createchannelrole {name} {channel}
/createchannelrole can only be invoked by users who have the `MANAGE_ROLES` permission
## /deletechannelrole {name} 
/deletechannelrole can only be invoked users who have the `MANAGE_ROLES` permission


